### PR TITLE
Adding args

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -13,7 +13,7 @@ pub struct Config {
 #[derive(Deserialize, Debug)]
 pub struct PackageManager {
     pub name: Value,
-    pub args: Value,
+    pub args: Option<Value>,
 }
 
 ///Contains the expected structure of [pkgs].
@@ -104,13 +104,19 @@ impl Config {
     }
 
     pub fn args_to_pkg_mgr(&self) -> Result<Vec<&str>, &'static str> {
-        if !self.package_manager.args.is_array() {
+        if self.package_manager.args.is_none() {
+            return Ok(vec![]);
+        }
+
+        let args = self.package_manager.args.as_ref().unwrap();
+
+        if !args.is_array() {
             return Err("expected field `args` of [package_manager] to be an array.");
         }
 
-        assert!(self.package_manager.args.as_array().is_some());
+        assert!(args.as_array().is_some());
 
-        let args_iter = self.package_manager.args.as_array().unwrap().iter();
+        let args_iter = args.as_array().unwrap().iter();
 
         Ok(args_iter
             .map(|arg| arg.as_str())

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,6 +13,7 @@ pub struct Config {
 #[derive(Deserialize, Debug)]
 pub struct PackageManager {
     pub name: Value,
+    pub args: Value,
 }
 
 ///Contains the expected structure of [pkgs].
@@ -80,7 +81,8 @@ impl Config {
             .map(|pkg| pkg.as_str())
             .filter(|pkg| pkg.is_some())
             .map(|pkg| pkg.unwrap())
-            .collect())
+            .collect()
+        )
     }
 
     pub fn pkg_mgr(&self) -> Result<&PkgMgrs, &'static str> {
@@ -99,5 +101,23 @@ impl Config {
                 .as_str()
                 .unwrap()
             ).expect("couldn't find package manager despite passing check."))
+    }
+
+    pub fn args_to_pkg_mgr(&self) -> Result<Vec<&str>, &'static str> {
+        if !self.package_manager.args.is_array() {
+            return Err("expected field `args` of [package_manager] to be an array.");
+        }
+
+        assert!(self.package_manager.args.as_array().is_some());
+
+        let args_iter = self.package_manager.args.as_array().unwrap().iter();
+
+        Ok(args_iter
+            .map(|arg| arg.as_str())
+            .filter(|arg| arg.is_some())
+            .map(|arg| arg.unwrap())
+            .collect()
+        )
+
     }
 }

--- a/src/install.rs
+++ b/src/install.rs
@@ -16,21 +16,29 @@ use crate::config::PkgMgrs;
 /// # Errors
 /// Can lead to errors if the command was malformed, if a process couldn't spawn,
 /// or std::process::Child.wait() fails.
-pub fn install_pkgs(package_manager: &PkgMgrs, packages: Vec<&str>) -> Result<(), Box<dyn Error>> {
+pub fn install_pkgs(package_manager: &PkgMgrs, args: Vec<&str>, packages: Vec<&str>) -> Result<(), Box<dyn Error>> {
     match package_manager {
-        PkgMgrs::Pacman => pacman(packages),
-        PkgMgrs::Yay => yay(packages),
+        PkgMgrs::Pacman => pacman(packages, args),
+        PkgMgrs::Yay => yay(packages, args),
     }
 }
 
-fn pacman(packages: Vec<&str>) -> Result<(), Box<dyn Error>> {
-    run_install_command(true, "pacman", vec!["-S", "--noconfirm"], packages)?;
+fn pacman(packages: Vec<&str>, mut args: Vec<&str>) -> Result<(), Box<dyn Error>> {
+    if !args.contains(&"-S") {
+        args.append(&mut vec!["-S"]);
+    }
+
+    run_install_command(true, "pacman", args, packages)?;
 
     Ok(())
 }
 
-fn yay(packages: Vec<&str>) -> Result<(), Box<dyn Error>> {
-    run_install_command(false, "yay", vec!["-S", "--noconfirm"], packages)?;
+fn yay(packages: Vec<&str>, mut args: Vec<&str>) -> Result<(), Box<dyn Error>> {
+    if !args.contains(&"-S") {
+        args.append(&mut vec!["-S"]);
+    }
+
+    run_install_command(false, "yay", args, packages)?;
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,10 +32,7 @@ fn main() {
         process::exit(1);
     });
 
-    let args_to_pkg_mgr = config.args_to_pkg_mgr().unwrap_or_else(|err| {
-        eprintln!("Error parsing config: {}", err);
-        process::exit(1);
-    });
+    let args_to_pkg_mgr = config.args_to_pkg_mgr().unwrap_or(vec![]);
 
     println!("{} Running install command.", "[frontier]".bold().purple());
     install::install_pkgs(pkg_mgr, args_to_pkg_mgr, pkgs_to_install).unwrap_or_else(|err| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,11 @@ fn main() {
         process::exit(1);
     });
 
-    let args_to_pkg_mgr = config.args_to_pkg_mgr().unwrap_or(vec![]);
+    // gets the args to the package manager
+    let args_to_pkg_mgr = config.args_to_pkg_mgr().unwrap_or_else(|err| {
+        eprintln!("Error parsing config: {}", err);
+        process::exit(1);
+    });
 
     println!("{} Running install command.", "[frontier]".bold().purple());
     install::install_pkgs(pkg_mgr, args_to_pkg_mgr, pkgs_to_install).unwrap_or_else(|err| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,8 +32,13 @@ fn main() {
         process::exit(1);
     });
 
+    let args_to_pkg_mgr = config.args_to_pkg_mgr().unwrap_or_else(|err| {
+        eprintln!("Error parsing config: {}", err);
+        process::exit(1);
+    });
+
     println!("{} Running install command.", "[frontier]".bold().purple());
-    install::install_pkgs(pkg_mgr, pkgs_to_install).unwrap_or_else(|err| {
+    install::install_pkgs(pkg_mgr, args_to_pkg_mgr, pkgs_to_install).unwrap_or_else(|err| {
         eprintln!("Error: {}", err);
         process::exit(1);
     });

--- a/test.toml
+++ b/test.toml
@@ -1,5 +1,6 @@
 [package_manager]
 name = "yay"
+args = ["--noconfirm"]
 
 [pkgs]
 install = [


### PR DESCRIPTION
Adds the `args` field under the [package_manager] section to allow the user to pass arguments to the package manager.